### PR TITLE
Support plugins that require sibling files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
+const path = require("path");
+
 module.exports = (context, request, callback) => {
   if (context.indexOf('tns-core-modules') !== -1
-    || context.indexOf('nativescript-') !== -1
-    || /^(tns-core-modules)/i.test(request)) {
+      || context.indexOf('nativescript-') !== -1
+      || /^(tns-core-modules)/i.test(request)) {
+    // support plugins requiring sibling files by rewriting fi. "./barcodescanner-common" to "nativescript-barcodescanner/barcodescanner-common"
+    if (request.indexOf("./") === 0) {
+      request = path.join(path.basename(context), request.substring(2));
+    }
     return callback(null, 'commonjs ' + request);
   }
   callback();


### PR DESCRIPTION
Per the comment in this PR's code ;)

It may be a bit of a monkey patch and only supports siblings (as opposed to traversing multiple folders), but it'll probably cover 90% of similar cases.